### PR TITLE
FIX: satogata journal 2022 url

### DIFF
--- a/journal/journal_2022.json
+++ b/journal/journal_2022.json
@@ -88,6 +88,6 @@
         "vol": "",
         "no": "",
         "page": "13pages",
-        "draft_pdf_url": "DOI:10.1109/THMS.2022.3207372"
+        "draft_pdf_url": "https://drive.google.com/file/d/15gIiAU_cUPUeTjXJDpDe0PEXJ9nE_Id9/view?usp=sharing"
     }
 ]


### PR DESCRIPTION
追加ありがとうございます。
本論文はOpen Accessではないのでドライブへのリンクを配置しました。
vol, no, pagesも修正がいるので、正式に公開され次第修正してmergeがよいとおもいます。
取り急ぎurlだけのPR作成しておきます。